### PR TITLE
Remove the current map display and hide full vessels.

### DIFF
--- a/Content.Client/_Afterlight/Latejoin/VesselListControl.xaml.cs
+++ b/Content.Client/_Afterlight/Latejoin/VesselListControl.xaml.cs
@@ -58,8 +58,11 @@ public sealed partial class VesselListControl : BoxContainer
         var itemsToRemove = new List<ItemList.Item>();
         foreach (var (key, item) in VesselItemList.Select(x => ((EntityUid)x.Metadata!, x)))
         {
-            if (!_gameTicker.StationNames.ContainsKey(key))
+            if ((!_gameTicker.StationNames.ContainsKey(key)) ||
+                (_gameTicker.JobsAvailable[key].Values.Sum(x => x ?? 0) <= 0))
+            {
                 itemsToRemove.Add(item);
+            }
         }
 
         foreach (var item in itemsToRemove)
@@ -69,7 +72,7 @@ public sealed partial class VesselListControl : BoxContainer
 
         foreach (var (key, name) in _gameTicker.StationNames)
         {
-            if (VesselItemList.Any(x => ((EntityUid)x.Metadata!) == key))
+            if (VesselItemList.Any(x => ((EntityUid)x.Metadata!) == key) || _gameTicker.JobsAvailable[key].Values.Sum(x => x ?? 0) <= 0)
                 continue;
 
             var item = new ItemList.Item(VesselItemList)

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -71,7 +71,7 @@ namespace Content.Server.GameTicking
             var gmTitle = Loc.GetString(Preset.ModeTitle);
             var desc = Loc.GetString(Preset.Description);
             return Loc.GetString(RunLevel == GameRunLevel.PreRoundLobby ? "game-ticker-get-info-preround-text" : "game-ticker-get-info-text",
-                ("roundId", RoundId), ("playerCount", playerCount), ("readyCount", readyCount), ("mapName", stationNames.ToString()),("gmTitle", gmTitle),("desc", desc));
+                ("roundId", RoundId), ("playerCount", playerCount), ("readyCount", readyCount), ("mapName", "The depths of interstellar space."),("gmTitle", gmTitle),("desc", desc));
         }
 
         private TickerLobbyReadyEvent GetStatusSingle(ICommonSession player, PlayerGameStatus gameStatus)


### PR DESCRIPTION
Vessels that're out of slots no longer clog the list.